### PR TITLE
Fixes gap between previous and current trace

### DIFF
--- a/src/DslOdeTrackedObject.cpp
+++ b/src/DslOdeTrackedObject.cpp
@@ -204,6 +204,10 @@ namespace DSL
         m_pBboxTrace = std::shared_ptr<std::deque<std::shared_ptr<NvBbox_Coords>>>(
             new std::deque<std::shared_ptr<NvBbox_Coords>>);
 
+        // Add last point of previous trace as first point to current trace to ensure
+        // a continuous line (line segment between previous-trace-end and current-trace-start) 
+        m_pBboxTrace->push_back(m_pPrevBboxTrace->back());
+
         preEventFrameCount = 1;
         onEventFrameCount = 0;
     }


### PR DESCRIPTION
@rjhowell44 with the changes of keeping the previous trace, there was a gap between the previous and current trace lines displayed. This is due the "missing" line segment between the last coordinate of the previous trace, and the start coordinate of the current trace.

This PR fixes this by adding the last bounding box of the previous trace as the start of the current trace on occurrence.

Please double check