### PR TITLE
Support/test new method to EOS pipeline on stop

### DIFF
--- a/src/DslPipelineBintr.cpp
+++ b/src/DslPipelineBintr.cpp
@@ -516,8 +516,15 @@ namespace DSL
         {
             m_eosFlag = true;
             
-            // Send an EOS event to the Pipline bin. 
+            // IMPORTANT! There are two methods to send the EOS event. 
+            // The best method is still under investigation. Only call one.
+
+            // 1. Send the event to the Pipeline bin
             SendEos();
+
+            // 2. Send the event to each Streammuxer sink pads connected
+            // to a Source component.  
+            // m_pPipelineSourcesBintr->EosAll();
             
             // once the EOS event has been received on all sink pads of all
             // elements, an EOS message will be posted on the bus. We need to

--- a/src/DslPipelineSourcesBintr.cpp
+++ b/src/DslPipelineSourcesBintr.cpp
@@ -405,9 +405,10 @@ namespace DSL
         // Send EOS message to each source object.
         for (auto const& imap: m_pChildSources)
         {
-            LOG_INFO("Sending EOS message to Source "  << imap.second->GetName());
-            gst_element_send_event(imap.second->GetGstElement(), 
-                gst_event_new_eos());
+            LOG_INFO("Sending EOS for Source "  << imap.second->GetName());
+            imap.second->NullSrcEosSinkMuxer();
+            // gst_element_send_event(imap.second->GetGstElement(), 
+            //     gst_event_new_eos());
         }
     }
     

--- a/src/DslSourceBintr.cpp
+++ b/src/DslSourceBintr.cpp
@@ -3520,7 +3520,6 @@ namespace DSL
             }
             m_pDepay->UnlinkFromSink();
             m_pParser->UnlinkFromSink();
-            m_pDecoder->UnlinkFromSink();
             UnlinkCommon();
         }
         m_isLinked = false;


### PR DESCRIPTION
implements
* #1246 

Also fixes issue in RTSP Source unlink all - should not unlink the Decoder which is unlinked in UnlinkCommon.  
